### PR TITLE
Fix RBAC Best practices violation

### DIFF
--- a/nirmata_test/cronjob-yaml/cronjob-nirmata-test.yaml
+++ b/nirmata_test/cronjob-yaml/cronjob-nirmata-test.yaml
@@ -28,6 +28,7 @@ spec:
           nodeSelector: {}
           serviceAccountName: "nirmata-test-sa"
           serviceAccount: "nirmata-test-sa"
+          automountServiceAccountToken: false
           schedulerName: "default-scheduler"
           dnsPolicy: "ClusterFirst"
           volumes:


### PR DESCRIPTION
Added automountServiceAccountToken: false to the cron job spec